### PR TITLE
fix tensorflow 1.0.0 docker image's issue 7960

### DIFF
--- a/1.0.0/Dockerfile
+++ b/1.0.0/Dockerfile
@@ -2,4 +2,9 @@ FROM tensorflow/tensorflow:1.0.0
 RUN sed -i 's/archive.ubuntu.com/mirrors.aliyun.com/' /etc/apt/sources.list
 COPY pip.conf /root/.pip/pip.conf
 
+RUN apt-get update \
+    && apt-get install libtcmalloc-minimal4 
+ENV LD_PRELOAD="/usr/lib/libtcmalloc_minimal.so.4"
+
+
 

--- a/1.0.0/Dockerfile-devel
+++ b/1.0.0/Dockerfile-devel
@@ -1,3 +1,7 @@
 FROM tensorflow/tensorflow:1.0.0-devel
 RUN sed -i 's/archive.ubuntu.com/mirrors.aliyun.com/' /etc/apt/sources.list
 COPY pip.conf /root/.pip/pip.conf
+
+RUN apt-get update \
+    && apt-get install libtcmalloc-minimal4 
+ENV LD_PRELOAD="/usr/lib/libtcmalloc_minimal.so.4"

--- a/1.0.0/Dockerfile-devel-gpu
+++ b/1.0.0/Dockerfile-devel-gpu
@@ -1,3 +1,7 @@
 FROM tensorflow/tensorflow:1.0.0-devel-gpu
 RUN sed -i 's/archive.ubuntu.com/mirrors.aliyun.com/' /etc/apt/sources.list
 COPY pip.conf /root/.pip/pip.conf
+
+RUN apt-get update \
+    && apt-get install libtcmalloc-minimal4 
+ENV LD_PRELOAD="/usr/lib/libtcmalloc_minimal.so.4"

--- a/1.0.0/Dockerfile-devel-gpu-py3
+++ b/1.0.0/Dockerfile-devel-gpu-py3
@@ -1,3 +1,7 @@
 FROM tensorflow/tensorflow:1.0.0-devel-gpu-py3
 RUN sed -i 's/archive.ubuntu.com/mirrors.aliyun.com/' /etc/apt/sources.list
 COPY pip.conf /root/.pip/pip.conf
+
+RUN apt-get update \
+    && apt-get install libtcmalloc-minimal4 
+ENV LD_PRELOAD="/usr/lib/libtcmalloc_minimal.so.4"

--- a/1.0.0/Dockerfile-devel-py3
+++ b/1.0.0/Dockerfile-devel-py3
@@ -1,3 +1,7 @@
 FROM tensorflow/tensorflow:1.0.0-devel-py3
 RUN sed -i 's/archive.ubuntu.com/mirrors.aliyun.com/' /etc/apt/sources.list
 COPY pip.conf /root/.pip/pip.conf
+
+RUN apt-get update \
+    && apt-get install libtcmalloc-minimal4 
+ENV LD_PRELOAD="/usr/lib/libtcmalloc_minimal.so.4"

--- a/1.0.0/Dockerfile-gpu
+++ b/1.0.0/Dockerfile-gpu
@@ -1,3 +1,7 @@
 FROM tensorflow/tensorflow:1.0.0-gpu
 RUN sed -i 's/archive.ubuntu.com/mirrors.aliyun.com/' /etc/apt/sources.list
 COPY pip.conf /root/.pip/pip.conf
+
+RUN apt-get update \
+    && apt-get install libtcmalloc-minimal4 
+ENV LD_PRELOAD="/usr/lib/libtcmalloc_minimal.so.4"

--- a/1.0.0/Dockerfile-gpu-py3
+++ b/1.0.0/Dockerfile-gpu-py3
@@ -1,3 +1,7 @@
 FROM tensorflow/tensorflow:1.0.0-gpu-py3
 RUN sed -i 's/archive.ubuntu.com/mirrors.aliyun.com/' /etc/apt/sources.list
 COPY pip.conf /root/.pip/pip.conf
+
+RUN apt-get update \
+    && apt-get install libtcmalloc-minimal4 
+ENV LD_PRELOAD="/usr/lib/libtcmalloc_minimal.so.4"

--- a/1.0.0/Dockerfile-py3
+++ b/1.0.0/Dockerfile-py3
@@ -2,4 +2,6 @@ FROM tensorflow/tensorflow:1.0.0-py3
 RUN sed -i 's/archive.ubuntu.com/mirrors.aliyun.com/' /etc/apt/sources.list
 COPY pip.conf /root/.pip/pip.conf
 
-
+RUN apt-get update \
+    && apt-get install libtcmalloc-minimal4 
+ENV LD_PRELOAD="/usr/lib/libtcmalloc_minimal.so.4"


### PR DESCRIPTION
Fix issue [double free or corruption (!prev) in Docker image tensorflow/tensorflow:1.0.0](https://github.com/tensorflow/tensorflow/issues/7960),  and we need to rebuild the tensorflow 1.0.0 docker image. You can also refer https://github.com/tensorflow/tensorflow/issues/6968.